### PR TITLE
Don't hardcode session in greeter

### DIFF
--- a/bin/lightdm-autologin-greeter
+++ b/bin/lightdm-autologin-greeter
@@ -17,7 +17,7 @@ greeter = None
 # or a failed login, in which case we tell the user
 def authentication_complete_cb(greeter):
     if greeter.get_is_authenticated():
-        if not greeter.start_session_sync("lightdm-xsession"):
+        if not greeter.start_session_sync(None):
             print("Failed to start session", file=sys.stderr)
     else:
         print("Login failed", file=sys.stderr)

--- a/share/lightdm/lightdm.conf.d/60-lightdm-autologin-greeter.conf
+++ b/share/lightdm/lightdm.conf.d/60-lightdm-autologin-greeter.conf
@@ -1,2 +1,3 @@
 [Seat:*]
 greeter-session=lightdm-autologin-greeter
+user-session=lightdm-xsession


### PR DESCRIPTION
Moves the hardcoded greeter session name into a configuration file.