### PR TITLE
get rid of error message: /bin/lightdm-autologin-greeter:12: PyGIWarn…

### DIFF
--- a/bin/lightdm-autologin-greeter
+++ b/bin/lightdm-autologin-greeter
@@ -6,6 +6,8 @@
 # http://people.ubuntu.com/~robert-ancell/lightdm/reference/
 
 from __future__ import print_function
+import gi
+gi.require_version('LightDM', '1')
 from gi.repository import GObject
 from gi.repository import LightDM
 import sys


### PR DESCRIPTION
…ing: LightDM was imported without specifying a version first. Use gi.require_version('LightDM', '1') before import to ensure that the right version gets loaded.